### PR TITLE
Implement single-copy strategy on convolution-based filters

### DIFF
--- a/engines/engines_benchmark_test.go
+++ b/engines/engines_benchmark_test.go
@@ -18,6 +18,11 @@ var (
 	// imageSize defines the width and height (in pixels) of the square dummy
 	// image used for benchmarking.
 	imageSize = flag.Int("imageSize", 5000, "Width and height (in pixels) of the square dummy image used for benchmarking.")
+
+	// sinkPixel servers as a anchor value to ensure that the Go's compiler
+	// won't skip the filter's execution. It is used to store the first value
+	// in the image.Pix[] array.
+	sinkPixel uint8
 )
 
 // BenchmarkExecuteSerial measures the performance and memory allocations of
@@ -31,12 +36,13 @@ func BenchmarkExecuteSerial(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Unknown filter: %s", *filterName)
 	}
-	
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img := generateDummyImage(*imageSize)
 		engines.ProcessRecipe(img, &recipe)
+		sinkPixel = img.Pix[0]
 	}
 }
 
@@ -50,12 +56,13 @@ func BenchmarkExecuteConcurrent(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Unknown filter: %s", *filterName)
 	}
-	
+
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img := generateDummyImage(*imageSize)
 		engines.ProcessRecipe(img, &recipe)
+		sinkPixel = img.Pix[0]
 	}
 }
 

--- a/filters/gaussian_blur/gaussian_blur.go
+++ b/filters/gaussian_blur/gaussian_blur.go
@@ -29,11 +29,9 @@ func GaussianBlur(img *image.RGBA) {
 	mainWg.Wait()
 }
 
-// gaussianBlurWorker process a subregion of the image by creating a padded
-// copy of the subregion and using it to compute the weighted color values for
-// each pixel within the partition. It ensures that no worker goroutine edits
-// certain parts of the original image before the others have finished their
-// copy stage.
+// gaussianBlurWorker process a subregion of the image by applying the gaussian
+// blur filter based on a global copy of the original image, computing the
+// weighted color values for each pixel within the partition.
 func gaussianBlurWorker(img, paddedCopy *image.RGBA, bounds image.Rectangle, kernel [][]float64, kernelOffset int, mainWg *sync.WaitGroup) {
 	defer mainWg.Done()
 

--- a/filters/gaussian_blur/gaussian_blur.go
+++ b/filters/gaussian_blur/gaussian_blur.go
@@ -17,14 +17,13 @@ func GaussianBlur(img *image.RGBA) {
 		imageStrips                  = imgutil.GetVerticalPartitions(bounds, numWorkers)
 		sigma                        = computeKernelSigma(kernelSize)
 		gaussianKernel, kernelOffset = generateGaussianKernel(kernelSize, sigma)
+		paddedCopy                   = imgutil.CreatePaddedCopy(*img, kernelOffset)
 		mainWg                       sync.WaitGroup
-		copyWg                       sync.WaitGroup
 	)
 
 	mainWg.Add(numWorkers)
-	copyWg.Add(numWorkers)
 	for strip := range imageStrips {
-		go gaussianBlurWorker(img, imageStrips[strip], gaussianKernel, kernelOffset, &mainWg, &copyWg)
+		go gaussianBlurWorker(img, &paddedCopy, imageStrips[strip], gaussianKernel, kernelOffset, &mainWg)
 	}
 
 	mainWg.Wait()
@@ -35,35 +34,32 @@ func GaussianBlur(img *image.RGBA) {
 // each pixel within the partition. It ensures that no worker goroutine edits
 // certain parts of the original image before the others have finished their
 // copy stage.
-func gaussianBlurWorker(img *image.RGBA, bounds image.Rectangle, kernel [][]float64, kernelOffset int, mainWg, copyWg *sync.WaitGroup) {
+func gaussianBlurWorker(img, paddedCopy *image.RGBA, bounds image.Rectangle, kernel [][]float64, kernelOffset int, mainWg *sync.WaitGroup) {
 	defer mainWg.Done()
-	copyImg := func() image.RGBA {
-		defer copyWg.Done()
-		return imgutil.CopyPaddedImagePartition(img, bounds, kernelOffset)
-	}()
 
-	paddedMinX, paddedMaxX := copyImg.Rect.Min.X+kernelOffset, copyImg.Rect.Max.X-kernelOffset
-	paddedMinY, paddedMaxY := copyImg.Rect.Min.Y+kernelOffset, copyImg.Rect.Max.Y-kernelOffset
+	originalBounds := img.Bounds()
+	paddedMinX := bounds.Min.X + kernelOffset
+	paddedMaxX := bounds.Max.X + kernelOffset
+	paddedMinY := bounds.Min.Y + kernelOffset
+	paddedMaxY := bounds.Max.Y + kernelOffset
 
 	for y := paddedMinY; y < paddedMaxY; y++ {
-		srcRowStart := (y - kernelOffset) * img.Stride
-		for x := paddedMinX; x < paddedMaxX; x++ {
-			if x == paddedMaxX-kernelOffset {
-				copyWg.Wait()
-			}
+		srcRow := (y - kernelOffset) * img.Stride
 
+		for x := paddedMinX; x < paddedMaxX; x++ {
 			var sumR, sumG, sumB, sumA, kernelWeightSum float64
+			srcCol := srcRow + (x-kernelOffset)*4
 
 			for ky := -kernelOffset; ky <= kernelOffset; ky++ {
 				for kx := -kernelOffset; kx <= kernelOffset; kx++ {
 					deltaX, deltaY := x+kx, y+ky
 
 					// disconsider padding pixels from blurring calculations
-					if !imgutil.IsPositionWithinOriginalImage(img, deltaX, deltaY, kernelOffset) {
+					if !imgutil.MapsToOriginalPixel(originalBounds, deltaX, deltaY, kernelOffset) {
 						continue
 					}
 
-					r, g, b, a := imgutil.GetRGBA8(&copyImg, deltaX, deltaY)
+					r, g, b, a := imgutil.GetRGBA8(paddedCopy, deltaX, deltaY)
 					kernelWeight := kernel[ky+kernelOffset][kx+kernelOffset]
 
 					sumR += float64(r) * kernelWeight
@@ -83,8 +79,7 @@ func gaussianBlurWorker(img *image.RGBA, bounds image.Rectangle, kernel [][]floa
 			}
 
 			updatedColor := []uint8{clamp256(sumR), clamp256(sumG), clamp256(sumB), clamp256(sumA)}
-			copyOffset := srcRowStart + (x-kernelOffset)*4
-			copy(img.Pix[copyOffset:copyOffset+4], updatedColor)
+			copy(img.Pix[srcCol:srcCol+4], updatedColor)
 		}
 	}
 }

--- a/filters/imgutil/copy.go
+++ b/filters/imgutil/copy.go
@@ -1,63 +1,54 @@
 package imgutil
 
-import "image"
+import (
+	"image"
+)
 
-// CopyPaddedImagePartition returns a new image.RGBA that represents a padded
-// copy of a specified rectangular region from the source image.
+// CreatePaddedCopy returns a new RGBA image that is a padded copy of the input
+// image. A padding P of black pixels is applied uniformly on all sides of the
+// original image, resulting in a new image that is larger by 2 * P in both
+// width and height.
 //
-// The padding value determines how many pixels are added around the region on
-// each side. Pixels in the padded area that fall outside the original image
-// bounds are filled with opaque black (0, 0, 0, 255).
-func CopyPaddedImagePartition(img *image.RGBA, bounds image.Rectangle, padding int) image.RGBA {
-	paddedBounds := getPaddedBounds(bounds, padding)
-	paddedImg := image.NewRGBA(paddedBounds)
+// Accessing the original image’s pixels within the padded copy requires
+// offsetting coordinates by the padding amount: (x + padding, y + padding).
+//
+// Assumptions:
+//   - The original image has bounds starting at (0, 0).
+//   - The returned image is safe to share across goroutines for read-only operations.
+func CreatePaddedCopy(img image.RGBA, padding int) image.RGBA {
+	originalBounds := img.Bounds()
 
-	for y := paddedBounds.Min.Y; y < paddedBounds.Max.Y; y++ {
-		copyRowStart := y * paddedImg.Stride
-		for x := paddedBounds.Min.X; x < paddedBounds.Max.X; x++ {
-			copyOffset := copyRowStart + (x-paddedImg.Rect.Min.X)*4
+	newMaxX := img.Rect.Max.X + (2 * padding)
+	newMaxY := img.Rect.Max.Y + (2 * padding)
+	copyImg := image.NewRGBA(image.Rect(0, 0, newMaxX, newMaxY))
 
-			if !IsPositionWithinOriginalImage(img, x, y, padding) {
-				copy(paddedImg.Pix[copyOffset:copyOffset+4], []uint8{0, 0, 0, 255})
-			} else {
-				srcRowStart := (y - padding) * img.Stride
-				srcOffset := srcRowStart + (x-padding-img.Rect.Min.X)*4
-				copy(paddedImg.Pix[copyOffset:copyOffset+4], img.Pix[srcOffset:srcOffset+4])
+	for y := copyImg.Rect.Min.Y; y < copyImg.Rect.Max.Y; y++ {
+		copyRow := y * copyImg.Stride
+
+		for x := copyImg.Rect.Min.X; x < copyImg.Rect.Max.X; x++ {
+			copyPixOffset := copyRow + (x * 4)
+
+			if !MapsToOriginalPixel(originalBounds, x, y, padding) {
+				copy(copyImg.Pix[copyPixOffset:copyPixOffset+4], []uint8{0, 0, 0, 255})
+				continue
 			}
+			
+			srcRow := (y - padding) * img.Stride
+			srcCol := srcRow + ((x - padding) * 4)
+			copy(copyImg.Pix[copyPixOffset:copyPixOffset+4], img.Pix[srcCol:srcCol+4])
 		}
 	}
 
-	return *paddedImg
+	return *copyImg
 }
 
-// IsPositionWithinOriginalImage determines whether the specified (x, y)
-// coordinate, adjusted by the given padding, falls within the bounds of the
-// original image. This is used to check if a padded pixel location corresponds
-// to a valid source pixel.
-func IsPositionWithinOriginalImage(img *image.RGBA, x, y, padding int) bool {
-	offsetX, offsetY := x-padding, y-padding
+// MapsToOriginalPixel checks whether a given (x, y) coordinate in the padded
+// image corresponds to a valid coordinate in the original, unpadded image. It
+// assumes that the original image's bounds start at (0, 0) (i.e.,
+// bounds.Min.X == 0 and bounds.Min.Y == 0).
+func MapsToOriginalPixel(bounds image.Rectangle, x, y, padding int) bool {
+	px := x - padding
+	py := y - padding
 
-	isXWithinBounds := offsetX >= img.Rect.Min.X && offsetX < img.Rect.Max.X
-	isYWithinBounds := offsetY >= img.Rect.Min.Y && offsetY < img.Rect.Max.Y
-
-	return isXWithinBounds && isYWithinBounds
-}
-
-// getPaddedBounds returns a new rectangle that extends the given bounds by the
-// specified padding on all sides. If the bounds of an axis start at its origin,
-// it ensures that padding is added only in the positive direction to avoid
-// negative coordinates.
-func getPaddedBounds(bounds image.Rectangle, padding int) image.Rectangle {
-	minX, maxX := bounds.Min.X-padding, bounds.Max.X+padding
-	minY, maxY := bounds.Min.Y-padding, bounds.Max.Y+padding
-
-	if bounds.Min.X == 0 {
-		minX, maxX = 0, bounds.Max.X+(2*padding)
-	}
-
-	if bounds.Min.Y == 0 {
-		minY, maxY = 0, bounds.Max.Y+(2*padding)
-	}
-
-	return image.Rect(minX, minY, maxX, maxY)
+	return (px >= 0 && px < bounds.Dx()) && (py >= 0 && py < bounds.Dy())
 }

--- a/filters/sobel/sobel.go
+++ b/filters/sobel/sobel.go
@@ -16,14 +16,13 @@ func Sobel(img *image.RGBA) {
 		bounds      = img.Bounds()
 		numWorkers  = imgutil.GetNumberOfWorkers(bounds)
 		imageStrips = imgutil.GetVerticalPartitions(bounds, numWorkers)
+		paddedCopy  = imgutil.CreatePaddedCopy(*img, copyPadding)
 		mainWg      sync.WaitGroup
-		copyWg      sync.WaitGroup
 	)
 
 	mainWg.Add(numWorkers)
-	copyWg.Add(numWorkers)
 	for strip := range imageStrips {
-		go sobelWorker(img, imageStrips[strip], &mainWg, &copyWg)
+		go sobelWorker(img, &paddedCopy, imageStrips[strip], &mainWg)
 	}
 
 	mainWg.Wait()
@@ -32,24 +31,19 @@ func Sobel(img *image.RGBA) {
 // sobelWorker processes a subregion of the image by applying the sobel filter
 // based on a global copy of the original image, which is used to compute the
 // gradients of each color channel.
-func sobelWorker(img *image.RGBA, bounds image.Rectangle, mainWg, copyWg *sync.WaitGroup) {
+func sobelWorker(srcImg, paddedCopy *image.RGBA, bounds image.Rectangle, mainWg *sync.WaitGroup) {
 	defer mainWg.Done()
-	copyImg := func() image.RGBA {
-		defer copyWg.Done()
-		return imgutil.CopyPaddedImagePartition(img, bounds, copyPadding)
-	}()
 
-	paddedMinX, paddedMaxX := copyImg.Rect.Min.X+copyPadding, copyImg.Rect.Max.X-copyPadding
-	paddedMinY, paddedMaxY := copyImg.Rect.Min.Y+copyPadding, copyImg.Rect.Max.Y-copyPadding
+	paddedMinX := bounds.Min.X + copyPadding
+	paddedMaxX := bounds.Max.X + copyPadding
+	paddedMinY := bounds.Min.Y + copyPadding
+	paddedMaxY := bounds.Max.Y + copyPadding
 
 	for y := paddedMinY; y < paddedMaxY; y++ {
-		srcRowStart := (y - copyPadding) * img.Stride
-		for x := paddedMinX; x < paddedMaxX; x++ {
-			if x == paddedMaxX-copyPadding {
-				copyWg.Wait()
-			}
+		srcRow := (y - copyPadding) * srcImg.Stride
 
-			offset := srcRowStart + (x-copyPadding)*4
+		for x := paddedMinX; x < paddedMaxX; x++ {
+			srcCol := srcRow + (x-copyPadding)*4
 
 			var r8, g8, b8, a8 uint8
 			var gxR, gxG, gxB, gyR, gyG, gyB int
@@ -59,7 +53,7 @@ func sobelWorker(img *image.RGBA, bounds image.Rectangle, mainWg, copyWg *sync.W
 					deltaX := x + kx
 					deltaY := y + ky
 
-					r8, g8, b8, a8 = imgutil.GetRGBA8(&copyImg, deltaX, deltaY)
+					r8, g8, b8, a8 = imgutil.GetRGBA8(paddedCopy, deltaX, deltaY)
 					r := int(r8)
 					g := int(g8)
 					b := int(b8)
@@ -81,7 +75,7 @@ func sobelWorker(img *image.RGBA, bounds image.Rectangle, mainWg, copyWg *sync.W
 			gradG := clampColorValue(math.Sqrt(float64(gxG*gxG + gyG*gyG)))
 			gradB := clampColorValue(math.Sqrt(float64(gxB*gxB + gyB*gyB)))
 
-			copy(img.Pix[offset:offset+4], []uint8{gradR, gradG, gradB, a8})
+			copy(srcImg.Pix[srcCol:srcCol+4], []uint8{gradR, gradG, gradB, a8})
 		}
 	}
 }

--- a/filters/sobel/sobel.go
+++ b/filters/sobel/sobel.go
@@ -29,8 +29,8 @@ func Sobel(img *image.RGBA) {
 }
 
 // sobelWorker processes a subregion of the image by applying the sobel filter
-// based on a global copy of the original image, which is used to compute the
-// gradients of each color channel.
+// based on a global copy of the original image, computing the kernel values of
+// each color channel of each pixel in the subregion.
 func sobelWorker(srcImg, paddedCopy *image.RGBA, bounds image.Rectangle, mainWg *sync.WaitGroup) {
 	defer mainWg.Done()
 


### PR DESCRIPTION
## Description

This PR closes #1 by replacing the per-thread padded copy strategy with a single, shared padded copy of the original image. This new approach ensures that all threads read from the same immutable source, fully eliminating the race conditions and unpredictable behavior previously caused by concurrent copy operations.

Additionally, benchmark inconsistencies were diagnosed and resolved. The issue stemmed from the Go compiler optimizing away the `engines.ProcessRecipe` call during benchmark runs, due to its lack of side effects and in-place processing model. This was addressed by ensuring observable behavior is retained during benchmarking.

## What this PR adds/modifies?
- [X] Replaces the per-thread image segment copy model with a single, global padded copy
- [X] Ensures thread-safe, read-only access to the shared padded image
- [X] Minor refactoring for readability

CLOSES #1 