### PR TITLE
Pipeline cleanup and refactoring

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,8 +5,13 @@
 MAX_WORKERS_PER_REQUEST=
 
 # Defines the maximum size, in MB, of processor requests. Requests larger than
-# the specified size will be denied.
+# the specified size will be denied. Defaults to 10 MB if not provided or
+# invalid.
 MAX_REQUEST_SIZE=
+
+# Defines the port to which the HTTP server will listen to requests. Defaults
+# to 8080 if not provided or invalid.
+API_SERVER_PORT=
 
 # Specifies the directory where processed images will be made avaliable for
 # users.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,27 +1,11 @@
 package main
 
 import (
-	"log"
-	"os"
-	"strconv"
-
 	"dougdomingos.com/image-filters/internals/api"
-	"dougdomingos.com/image-filters/internals/utils"
 	"github.com/joho/godotenv"
 )
 
 func main() {
 	godotenv.Load()
-
-	requiredVars := []string{"API_OUTPUT_DIR", "MAX_REQUEST_SIZE"}
-	if err := utils.EnsureRequiredEnvVars(requiredVars); err != nil {
-		log.Fatal(err)
-	}
-
-	serverPort, err := strconv.Atoi(os.Getenv("API_SERVER_PORT"))
-	if err != nil {
-		serverPort = 8080
-	}
-
-	api.StartHTTPServer(serverPort)
+	api.StartHTTPServer()
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -13,13 +13,9 @@ import (
 func main() {
 	godotenv.Load()
 
-	requiredEnvVars := []string{"API_OUTPUT_DIR", "MAX_REQUEST_SIZE"}
-	for _, key := range requiredEnvVars {
-		if x, err := utils.GetEnvVar(key); err != nil {
-			log.Fatalf("[ERROR] Missing required environment variable: %s\n", key)
-		} else {
-			log.Print(key, x)
-		}
+	requiredVars := []string{"API_OUTPUT_DIR", "MAX_REQUEST_SIZE"}
+	if err := utils.EnsureRequiredEnvVars(requiredVars); err != nil {
+		log.Fatal(err)
 	}
 
 	serverPort, err := strconv.Atoi(os.Getenv("API_SERVER_PORT"))

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"log"
+	"os"
+	"strconv"
 
 	"dougdomingos.com/image-filters/internals/api"
 	"dougdomingos.com/image-filters/internals/utils"
@@ -20,5 +22,10 @@ func main() {
 		}
 	}
 
-	api.StartHTTPServer()
+	serverPort, err := strconv.Atoi(os.Getenv("API_SERVER_PORT"))
+	if err != nil {
+		serverPort = 8080
+	}
+
+	api.StartHTTPServer(serverPort)
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,6 +10,6 @@ func main() {
 	if flags.ListPipelines {
 		cli.ListAvaliablePipelines()
 	} else {
-		cli.ApplyRecipeToImage(flags.ImgPath, flags.OutputDir, flags.Filters)
+		cli.ApplyPipelineToImage(flags.ImgPath, flags.OutputDir, flags.Filters)
 	}
 }

--- a/engines/engines_benchmark_test.go
+++ b/engines/engines_benchmark_test.go
@@ -32,7 +32,7 @@ var (
 // the serial execution multiple times, reporting time and allocation statistics.
 func BenchmarkExecuteSerial(b *testing.B) {
 	os.Setenv("MAX_WORKERS_PER_REQUEST", "1")
-	recipe, err := pipelines.NewPipeline(strings.Split(*filterName, ","))
+	pipeline, err := pipelines.NewPipeline(strings.Split(*filterName, ","))
 	if err != nil {
 		b.Fatalf("Unknown filter: %s", *filterName)
 	}
@@ -41,7 +41,7 @@ func BenchmarkExecuteSerial(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img := generateDummyImage(*imageSize)
-		engines.ProcessPipeline(img, &recipe)
+		engines.ProcessPipeline(img, &pipeline)
 		sinkPixel = img.Pix[0]
 	}
 }
@@ -52,7 +52,7 @@ func BenchmarkExecuteSerial(b *testing.B) {
 // multiple times, reporting time and allocation statistics.
 func BenchmarkExecuteConcurrent(b *testing.B) {
 	os.Unsetenv("MAX_WORKERS_PER_REQUEST")
-	recipe, err := pipelines.NewPipeline(strings.Split(*filterName, ","))
+	pipeline, err := pipelines.NewPipeline(strings.Split(*filterName, ","))
 	if err != nil {
 		b.Fatalf("Unknown filter: %s", *filterName)
 	}
@@ -61,7 +61,7 @@ func BenchmarkExecuteConcurrent(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img := generateDummyImage(*imageSize)
-		engines.ProcessPipeline(img, &recipe)
+		engines.ProcessPipeline(img, &pipeline)
 		sinkPixel = img.Pix[0]
 	}
 }

--- a/engines/engines_benchmark_test.go
+++ b/engines/engines_benchmark_test.go
@@ -32,7 +32,7 @@ var (
 // the serial execution multiple times, reporting time and allocation statistics.
 func BenchmarkExecuteSerial(b *testing.B) {
 	os.Setenv("MAX_WORKERS_PER_REQUEST", "1")
-	recipe, err := pipelines.BuildRecipe(strings.Split(*filterName, ","))
+	recipe, err := pipelines.NewPipeline(strings.Split(*filterName, ","))
 	if err != nil {
 		b.Fatalf("Unknown filter: %s", *filterName)
 	}
@@ -41,7 +41,7 @@ func BenchmarkExecuteSerial(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img := generateDummyImage(*imageSize)
-		engines.ProcessRecipe(img, &recipe)
+		engines.ProcessPipeline(img, &recipe)
 		sinkPixel = img.Pix[0]
 	}
 }
@@ -52,7 +52,7 @@ func BenchmarkExecuteSerial(b *testing.B) {
 // multiple times, reporting time and allocation statistics.
 func BenchmarkExecuteConcurrent(b *testing.B) {
 	os.Unsetenv("MAX_WORKERS_PER_REQUEST")
-	recipe, err := pipelines.BuildRecipe(strings.Split(*filterName, ","))
+	recipe, err := pipelines.NewPipeline(strings.Split(*filterName, ","))
 	if err != nil {
 		b.Fatalf("Unknown filter: %s", *filterName)
 	}
@@ -61,7 +61,7 @@ func BenchmarkExecuteConcurrent(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		img := generateDummyImage(*imageSize)
-		engines.ProcessRecipe(img, &recipe)
+		engines.ProcessPipeline(img, &recipe)
 		sinkPixel = img.Pix[0]
 	}
 }

--- a/engines/filter_engine.go
+++ b/engines/filter_engine.go
@@ -6,12 +6,13 @@ import (
 	"dougdomingos.com/image-filters/pipelines"
 )
 
-func ProcessRecipe(img *image.RGBA, recipe *pipelines.Recipe) {
-	for step := recipe.Head; step != nil; step = recipe.NextStep() {
-		if step.Action.Preprocess != nil {
-			step.Action.Preprocess(img)
-		}
+func ProcessPipeline(img *image.RGBA, pipeline *pipelines.Pipeline) {
+	if pipeline.IsEmpty() {
+		return
+	}
 
-		step.Action.Filter(img)
+	currentStep := pipeline.Peek()
+	for !pipeline.IsEmpty() {
+		currentStep.Filter.ApplyFilter(img)
 	}
 }

--- a/engines/filter_engine.go
+++ b/engines/filter_engine.go
@@ -1,18 +1,30 @@
 package engines
 
 import (
+	"fmt"
 	"image"
 
 	"dougdomingos.com/image-filters/pipelines"
 )
 
-func ProcessPipeline(img *image.RGBA, pipeline *pipelines.Pipeline) {
-	if pipeline.IsEmpty() {
-		return
+// ProcessPipeline sequentially applies all filters defined in the given
+// pipeline to the provided image.
+//
+// If the provided pipeline is nil, empty or contains a PipelineStep with a nil
+// Filter, processing stops and an error is returned. Otherwise, returns nil.
+func ProcessPipeline(img *image.RGBA, pipeline *pipelines.Pipeline) error {
+	if pipeline == nil || pipeline.IsEmpty() {
+		return fmt.Errorf("[ERROR] unable to process empty pipeline")
 	}
 
-	currentStep := pipeline.Peek()
 	for !pipeline.IsEmpty() {
+		currentStep := pipeline.NextStep()
+		if currentStep.Filter == nil {
+			return fmt.Errorf("[ERROR] pipeline step has no filter")
+		}
+
 		currentStep.Filter.ApplyFilter(img)
 	}
+
+	return nil
 }

--- a/filters/binarization/action.go
+++ b/filters/binarization/action.go
@@ -10,11 +10,11 @@
 package binarization
 
 import (
-	"dougdomingos.com/image-filters/filters"
 	"dougdomingos.com/image-filters/filters/grayscale"
+	"dougdomingos.com/image-filters/filters/types"
 )
 
-var BinarizationAction = filters.Action{
+var BinarizationAction = types.Action{
 	Preprocess: grayscale.Grayscale,
 	Filter:     Binarization,
 }

--- a/filters/binarization/action.go
+++ b/filters/binarization/action.go
@@ -14,7 +14,4 @@ import (
 	"dougdomingos.com/image-filters/filters/types"
 )
 
-var BinarizationAction = types.Action{
-	Preprocess: grayscale.Grayscale,
-	Filter:     Binarization,
-}
+var BinarizationFilter = types.NewFilter(grayscale.Grayscale, Binarization)

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -16,24 +16,24 @@ import (
 
 // AvailableFilters maps a string identifier to its corresponding filter
 // action.
-var AvaliableFilters = map[string]types.Action{
-	"binarization":     binarization.BinarizationAction,
-	"grayscale":        grayscale.GrayscaleAction,
-	"horizontal-flip":  horizontal_flip.HorizontalFlipAction,
-	"sobel":            sobel.SobelAction,
-	"sobel-grayscaled": sobel.SobelGrayscaledAction,
-	"vertical-flip":    vertical_flip.VerticalFlipAction,
-	"gaussian-blur":    gaussian_blur.GaussianBlurAction,
+var AvaliableFilters = map[string]types.Filter{
+	"binarization":     binarization.BinarizationFilter,
+	"grayscale":        grayscale.GrayscaleFilter,
+	"horizontal-flip":  horizontal_flip.HorizontalFlipFilter,
+	"sobel":            sobel.SobelFilter,
+	"sobel-grayscaled": sobel.SobelGrayscaledFilter,
+	"vertical-flip":    vertical_flip.VerticalFlipFilter,
+	"gaussian-blur":    gaussian_blur.GaussianBlurFilter,
 	// add more actions here...
 }
 
-// GetFilterAction retrieves a filter pipeline by its name from the
-// AvailableFilters map. It returns the pipeline if found, or an error if the
-// specified name is not defined.
-func GetFilterAction(filterID string) (types.Action, error) {
+// GetFilter retrieves a filter by its name from the AvailableFilters map.
+// It returns the filter, if present, or an error if the specified filter is
+// not defined.
+func GetFilter(filterID string) (types.Filter, error) {
 	pipeline, exists := AvaliableFilters[filterID]
 	if !exists {
-		return types.Action{}, fmt.Errorf("[ERROR]: Specified filter does not exist")
+		return types.Filter{}, fmt.Errorf("[ERROR]: Specified filter does not exist")
 	}
 
 	return pipeline, nil

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -24,7 +24,7 @@ var AvaliableFilters = map[string]types.Filter{
 	"sobel-grayscaled": sobel.SobelGrayscaledFilter,
 	"vertical-flip":    vertical_flip.VerticalFlipFilter,
 	"gaussian-blur":    gaussian_blur.GaussianBlurFilter,
-	// add more actions here...
+	// add more filters here...
 }
 
 // GetFilter retrieves a filter by its name from the AvailableFilters map.
@@ -37,4 +37,16 @@ func GetFilter(filterID string) (types.Filter, error) {
 	}
 
 	return pipeline, nil
+}
+
+// GetAvaliableFilterIDs returns a slice containing the identifiers of all
+// filters declared in the AvaliableFilters map.
+func GetAvaliableFilterIDs() []string {
+	filterIDs := make([]string, 0, len(AvaliableFilters))
+
+	for filterKey := range AvaliableFilters {
+		filterIDs = append(filterIDs, filterKey)
+	}
+
+	return filterIDs
 }

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -1,20 +1,22 @@
-package pipelines
+// Package filters provides a set of image filters implemented using
+// pixel-based manipulation techniques.
+package filters
 
 import (
 	"fmt"
 
-	"dougdomingos.com/image-filters/filters"
 	"dougdomingos.com/image-filters/filters/binarization"
 	"dougdomingos.com/image-filters/filters/gaussian_blur"
 	"dougdomingos.com/image-filters/filters/grayscale"
 	"dougdomingos.com/image-filters/filters/horizontal_flip"
 	"dougdomingos.com/image-filters/filters/sobel"
+	"dougdomingos.com/image-filters/filters/types"
 	"dougdomingos.com/image-filters/filters/vertical_flip"
 )
 
 // AvailableFilters maps a string identifier to its corresponding filter
-// pipeline.
-var AvaliableFilters = map[string]filters.Action{
+// action.
+var AvaliableFilters = map[string]types.Action{
 	"binarization":     binarization.BinarizationAction,
 	"grayscale":        grayscale.GrayscaleAction,
 	"horizontal-flip":  horizontal_flip.HorizontalFlipAction,
@@ -22,16 +24,16 @@ var AvaliableFilters = map[string]filters.Action{
 	"sobel-grayscaled": sobel.SobelGrayscaledAction,
 	"vertical-flip":    vertical_flip.VerticalFlipAction,
 	"gaussian-blur":    gaussian_blur.GaussianBlurAction,
-	// add more filters here...
+	// add more actions here...
 }
 
-// GetFilterPipeline retrieves a filter pipeline by its name from the
+// GetFilterAction retrieves a filter pipeline by its name from the
 // AvailableFilters map. It returns the pipeline if found, or an error if the
 // specified name is not defined.
-func GetFilterPipeline(filterName string) (filters.Action, error) {
-	pipeline, exists := AvaliableFilters[filterName]
+func GetFilterAction(filterID string) (types.Action, error) {
+	pipeline, exists := AvaliableFilters[filterID]
 	if !exists {
-		return filters.Action{}, fmt.Errorf("[ERROR]: Specified filter does not exist")
+		return types.Action{}, fmt.Errorf("[ERROR]: Specified filter does not exist")
 	}
 
 	return pipeline, nil

--- a/filters/gaussian_blur/action.go
+++ b/filters/gaussian_blur/action.go
@@ -7,9 +7,9 @@
 // (represented by sigma, or "σ").
 package gaussian_blur
 
-import "dougdomingos.com/image-filters/filters"
+import "dougdomingos.com/image-filters/filters/types"
 
-var GaussianBlurAction = filters.Action{
+var GaussianBlurAction = types.Action{
 	Preprocess: nil,
 	Filter:     GaussianBlur,
 }

--- a/filters/gaussian_blur/action.go
+++ b/filters/gaussian_blur/action.go
@@ -9,7 +9,4 @@ package gaussian_blur
 
 import "dougdomingos.com/image-filters/filters/types"
 
-var GaussianBlurAction = types.Action{
-	Preprocess: nil,
-	Filter:     GaussianBlur,
-}
+var GaussianBlurFilter = types.NewFilter(nil, GaussianBlur)

--- a/filters/grayscale/action.go
+++ b/filters/grayscale/action.go
@@ -6,11 +6,9 @@
 // The alpha channel is left unmodified.
 package grayscale
 
-import (
-	"dougdomingos.com/image-filters/filters"
-)
+import "dougdomingos.com/image-filters/filters/types"
 
-var GrayscaleAction = filters.Action{
+var GrayscaleAction = types.Action{
 	Preprocess: nil,
 	Filter:     Grayscale,
 }

--- a/filters/grayscale/action.go
+++ b/filters/grayscale/action.go
@@ -8,7 +8,4 @@ package grayscale
 
 import "dougdomingos.com/image-filters/filters/types"
 
-var GrayscaleAction = types.Action{
-	Preprocess: nil,
-	Filter:     Grayscale,
-}
+var GrayscaleFilter = types.NewFilter(nil, Grayscale)

--- a/filters/horizontal_flip/action.go
+++ b/filters/horizontal_flip/action.go
@@ -6,7 +6,4 @@ package horizontal_flip
 
 import "dougdomingos.com/image-filters/filters/types"
 
-var HorizontalFlipAction = types.Action{
-	Preprocess: nil,
-	Filter:     HorizontalFlip,
-}
+var HorizontalFlipFilter = types.NewFilter(nil, HorizontalFlip)

--- a/filters/horizontal_flip/action.go
+++ b/filters/horizontal_flip/action.go
@@ -4,11 +4,9 @@
 // effectively mirroring the image along its vertical axis.
 package horizontal_flip
 
-import (
-	"dougdomingos.com/image-filters/filters"
-)
+import "dougdomingos.com/image-filters/filters/types"
 
-var HorizontalFlipAction = filters.Action{
+var HorizontalFlipAction = types.Action{
 	Preprocess: nil,
 	Filter:     HorizontalFlip,
 }

--- a/filters/imgutil/partition.go
+++ b/filters/imgutil/partition.go
@@ -49,7 +49,7 @@ func GetNumberOfWorkers(bounds image.Rectangle) int {
 	maxWorkers := runtime.NumCPU()
 
 	envVar, isDeclared := os.LookupEnv("MAX_WORKERS_PER_REQUEST")
-	if !isDeclared && envVar != "" {
+	if isDeclared && envVar != "" {
 		if envWorkersVal, err := strconv.Atoi(envVar); err == nil {
 			maxWorkers = envWorkersVal
 		}

--- a/filters/imgutil/partition.go
+++ b/filters/imgutil/partition.go
@@ -3,10 +3,9 @@ package imgutil
 import (
 	"image"
 	"math"
+	"os"
 	"runtime"
 	"strconv"
-
-	"dougdomingos.com/image-filters/internals/utils"
 )
 
 // GetVerticalPartitions splits an image's bounds into an arbitrary number of
@@ -49,8 +48,8 @@ func GetHorizontalPartitions(bounds image.Rectangle, segments int) []image.Recta
 func GetNumberOfWorkers(bounds image.Rectangle) int {
 	maxWorkers := runtime.NumCPU()
 
-	envVar, err := utils.GetEnvVar("MAX_WORKERS_PER_REQUEST")
-	if err == nil && envVar != "" {
+	envVar, isDeclared := os.LookupEnv("MAX_WORKERS_PER_REQUEST")
+	if !isDeclared && envVar != "" {
 		if envWorkersVal, err := strconv.Atoi(envVar); err == nil {
 			maxWorkers = envWorkersVal
 		}

--- a/filters/sobel/action.go
+++ b/filters/sobel/action.go
@@ -8,16 +8,16 @@
 package sobel
 
 import (
-	"dougdomingos.com/image-filters/filters"
 	"dougdomingos.com/image-filters/filters/grayscale"
+	"dougdomingos.com/image-filters/filters/types"
 )
 
-var SobelAction = filters.Action{
+var SobelAction = types.Action{
 	Preprocess: nil,
 	Filter:     Sobel,
 }
 
-var SobelGrayscaledAction = filters.Action{
+var SobelGrayscaledAction = types.Action{
 	Preprocess: grayscale.Grayscale,
 	Filter:     Sobel,
 }

--- a/filters/sobel/action.go
+++ b/filters/sobel/action.go
@@ -12,12 +12,5 @@ import (
 	"dougdomingos.com/image-filters/filters/types"
 )
 
-var SobelAction = types.Action{
-	Preprocess: nil,
-	Filter:     Sobel,
-}
-
-var SobelGrayscaledAction = types.Action{
-	Preprocess: grayscale.Grayscale,
-	Filter:     Sobel,
-}
+var SobelFilter = types.NewFilter(nil, Sobel)
+var SobelGrayscaledFilter = types.NewFilter(grayscale.Grayscale, Sobel)

--- a/filters/types/types.go
+++ b/filters/types/types.go
@@ -1,6 +1,4 @@
-// Package filters provides a set of image filters implemented using
-// pixel-based manipulation techniques.
-package filters
+package types
 
 import "image"
 

--- a/filters/types/types.go
+++ b/filters/types/types.go
@@ -2,12 +2,47 @@ package types
 
 import "image"
 
-// Filter is a function that applies a specific effect to the provided image.
-// All pixel operations are done in-place, and implementations are thread-safe
-// by default.
-type Filter func(image *image.RGBA)
+// Transformation defines a single image operation that modifies the provided
+// instance in-place. Implementations are expected to be thread-safe.
+type Transformation func(img *image.RGBA)
 
-type Action struct {
-	Preprocess Filter
-	Filter Filter
+// Filter defines an image transformation composed of optional pre-processing
+// and required processing steps.
+type Filter struct {
+
+	// preprocess applies an optional pre-processing transformation to the
+	// image prior to the main processing step. If nil, no pre-processing is
+	// applied.
+	preprocess Transformation
+
+	// apply performs the main transformation on the image. This function must
+	// not be nil.
+	apply Transformation
+}
+
+// ApplyFilter applies the filter to the provided image. If a pre-processing
+// function is defined, it is applied first, followed by the main transformation.
+//
+// The operation is performed in-place and modifies the original image.
+func (filter *Filter) ApplyFilter(img *image.RGBA) {
+	if filter.preprocess != nil {
+		filter.preprocess(img)
+	}
+
+	filter.apply(img)
+}
+
+// NewFilter constructs a new Filter from the given pre-processing and main
+// processing functions. The main processing function must be non-nil.
+//
+// If 'main' is nil, the returned Filter will be a zero value (invalid).
+func NewFilter(pre, main Transformation) Filter {
+	if main == nil {
+		panic("BuildFilter: 'main' processing function must not be nil")
+	}
+
+	return Filter{
+		preprocess: pre,
+		apply:      main,
+	}
 }

--- a/filters/vertical_flip/action.go
+++ b/filters/vertical_flip/action.go
@@ -8,7 +8,4 @@ import (
 	"dougdomingos.com/image-filters/filters/types"
 )
 
-var VerticalFlipAction = types.Action{
-	Preprocess: nil,
-	Filter:     VerticalFlip,
-}
+var VerticalFlipFilter = types.NewFilter(nil, VerticalFlip)

--- a/filters/vertical_flip/action.go
+++ b/filters/vertical_flip/action.go
@@ -4,9 +4,11 @@
 // effectively mirroring the image along its horizontal axis.
 package vertical_flip
 
-import "dougdomingos.com/image-filters/filters"
+import (
+	"dougdomingos.com/image-filters/filters/types"
+)
 
-var VerticalFlipAction = filters.Action{
+var VerticalFlipAction = types.Action{
 	Preprocess: nil,
 	Filter:     VerticalFlip,
 }

--- a/internals/api/dto/benchmark_dto.go
+++ b/internals/api/dto/benchmark_dto.go
@@ -12,7 +12,7 @@ import (
 type BenchmarkRequestDTO struct {
 
 	// Recipe represents the list of filters to be applied to the dummy image.
-	Recipe pipelines.Recipe
+	Recipe pipelines.Pipeline
 
 	// TestImageSize is the requested dimensions for the dummy image to be used
 	// on the benchmark tests.

--- a/internals/api/dto/benchmark_dto.go
+++ b/internals/api/dto/benchmark_dto.go
@@ -11,8 +11,8 @@ import (
 // benchmark request.
 type BenchmarkRequestDTO struct {
 
-	// Recipe represents the list of filters to be applied to the dummy image.
-	Recipe pipelines.Pipeline
+	// Pipeline represents the list of filters to be applied to the dummy image.
+	Pipeline pipelines.Pipeline
 
 	// TestImageSize is the requested dimensions for the dummy image to be used
 	// on the benchmark tests.

--- a/internals/api/dto/benchmark_dto.go
+++ b/internals/api/dto/benchmark_dto.go
@@ -11,6 +11,7 @@ import (
 // benchmark request.
 type BenchmarkRequestDTO struct {
 
+	// Recipe represents the list of filters to be applied to the dummy image.
 	Recipe pipelines.Recipe
 
 	// TestImageSize is the requested dimensions for the dummy image to be used

--- a/internals/api/dto/list_filters_dto.go
+++ b/internals/api/dto/list_filters_dto.go
@@ -1,0 +1,7 @@
+package dto
+
+// ListFiltersResponse represents the JSON response for listing the avaliable
+// filters in the API.
+type ListFiltersResponse struct {
+	Filters []string `json:"filters"`
+}

--- a/internals/api/dto/processor_dto.go
+++ b/internals/api/dto/processor_dto.go
@@ -20,8 +20,8 @@ type ProcessorRequestDTO struct {
 	// ImgFilename is the name of the image file sent through the request.
 	ImgFilename string
 
-	// Recipe represents the list of filters to be applied to the image.
-	Recipe pipelines.Pipeline
+	// Pipeline represents the list of filters to be applied to the image.
+	Pipeline pipelines.Pipeline
 }
 
 // ProcessorResponseDTO represents the JSON for processor HTTP responses.

--- a/internals/api/dto/processor_dto.go
+++ b/internals/api/dto/processor_dto.go
@@ -21,7 +21,7 @@ type ProcessorRequestDTO struct {
 	ImgFilename string
 
 	// Recipe represents the list of filters to be applied to the image.
-	Recipe pipelines.Recipe
+	Recipe pipelines.Pipeline
 }
 
 // ProcessorResponseDTO represents the JSON for processor HTTP responses.

--- a/internals/api/dto/processor_dto.go
+++ b/internals/api/dto/processor_dto.go
@@ -20,6 +20,7 @@ type ProcessorRequestDTO struct {
 	// ImgFilename is the name of the image file sent through the request.
 	ImgFilename string
 
+	// Recipe represents the list of filters to be applied to the image.
 	Recipe pipelines.Recipe
 }
 

--- a/internals/api/router.go
+++ b/internals/api/router.go
@@ -16,8 +16,9 @@ import (
 func buildRouter() *http.ServeMux {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/process", services.ProcessorHandler)
 	mux.HandleFunc("/bench", services.BenchmarkHandler)
+	mux.HandleFunc("/filters", services.ListFilterHandler)
+	mux.HandleFunc("/filters/process", services.ProcessorHandler)
 	mux.HandleFunc("/images/", createFileHandler(os.Getenv("API_OUTPUT_DIR"), "/images/"))
 
 	return mux

--- a/internals/api/router.go
+++ b/internals/api/router.go
@@ -49,6 +49,8 @@ func withRequestLogger(next http.Handler) http.Handler {
 	})
 }
 
+// createFileHandler creates a http.HandlerFunc specialized on serving requests
+// to images within the specified output directory.
 func createFileHandler(outputDir string, prefix string) http.HandlerFunc {
 	fs := http.FileServer(http.Dir(outputDir))
 

--- a/internals/api/server.go
+++ b/internals/api/server.go
@@ -28,6 +28,9 @@ func StartHTTPServer() {
 	}
 }
 
+// getServerPort returns the port to which the HTTP server will listen for
+// requests. It reads the API_SERVER_PORT environment variable, and defaults to
+// 8080 if such variable is not declared or has an invalid value.
 func getServerPort() int {
 	serverPort, err := strconv.Atoi(os.Getenv("API_SERVER_PORT"))
 	if err != nil {

--- a/internals/api/server.go
+++ b/internals/api/server.go
@@ -1,16 +1,19 @@
 package api
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 )
 
 // StartHTTPServer initiates the API HTTP server with the specified routes.
 // By default, the server listens to port 8080.
-func StartHTTPServer() {
+func StartHTTPServer(port int) {
 	router := withRequestLogger(buildRouter())
+	address := fmt.Sprintf(":%d", port)
 
-	if err := http.ListenAndServe(":8080", router); err != nil {
+	log.Printf("Starting HTTP server on port %d\n", port)
+	if err := http.ListenAndServe(address, router); err != nil {
 		log.Fatalf("Could not start HTTP server: %s\n", err.Error())
 	}
 }

--- a/internals/api/server.go
+++ b/internals/api/server.go
@@ -4,16 +4,35 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
+
+	"dougdomingos.com/image-filters/internals/utils"
 )
 
 // StartHTTPServer initiates the API HTTP server with the specified routes.
 // By default, the server listens to port 8080.
-func StartHTTPServer(port int) {
+func StartHTTPServer() {
 	router := withRequestLogger(buildRouter())
+	port := getServerPort()
 	address := fmt.Sprintf(":%d", port)
+
+	requiredVars := []string{"API_OUTPUT_DIR", "MAX_REQUEST_SIZE"}
+	if err := utils.EnsureRequiredEnvVars(requiredVars); err != nil {
+		log.Fatal(err)
+	}
 
 	log.Printf("Starting HTTP server on port %d\n", port)
 	if err := http.ListenAndServe(address, router); err != nil {
 		log.Fatalf("Could not start HTTP server: %s\n", err.Error())
 	}
+}
+
+func getServerPort() int {
+	serverPort, err := strconv.Atoi(os.Getenv("API_SERVER_PORT"))
+	if err != nil {
+		serverPort = 8080
+	}
+
+	return serverPort
 }

--- a/internals/api/services/benchmark.go
+++ b/internals/api/services/benchmark.go
@@ -22,8 +22,8 @@ func BenchmarkHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dummyImg := image.NewRGBA(image.Rect(0, 0, requestData.TestImageSize, requestData.TestImageSize))
-	serialRuntime := benchmarkRecipe(requestData.Recipe, *dummyImg)
-	concurrentRuntime := benchmarkRecipe(requestData.Recipe, *dummyImg)
+	serialRuntime := benchmarkPipeline(requestData.Pipeline, *dummyImg)
+	concurrentRuntime := benchmarkPipeline(requestData.Pipeline, *dummyImg)
 
 	response := dto.BuildBenchmarkResponse(requestData.TestImageSize, serialRuntime, concurrentRuntime)
 	sendJSONResponse(w, response, statusCode)
@@ -47,22 +47,22 @@ func parseBenchmarkRequest(r *http.Request) (*dto.BenchmarkRequestDTO, int, stri
 		return nil, http.StatusBadRequest, "Parameter \"sample-size\" must be numeric"
 	}
 
-	recipe, err := pipelines.NewPipeline(strings.Split(filters, ","))
+	pipeline, err := pipelines.NewPipeline(strings.Split(filters, ","))
 	if err != nil {
 		return nil, http.StatusNotFound, fmt.Sprintf("Requested filter \"%s\" does not exist", filters)
 	}
 
 	return &dto.BenchmarkRequestDTO{
-		Recipe:        recipe,
+		Pipeline:      pipeline,
 		TestImageSize: castedSampleSize,
 	}, http.StatusOK, ""
 }
 
-// benchmarkRecipe determines the total time spent on a recipe execution,
+// benchmarkPipeline determines the total time spent on a pipeline execution,
 // returning the result time in milliseconds.
-func benchmarkRecipe(recipe pipelines.Pipeline, img image.RGBA) int64 {
+func benchmarkPipeline(pipeline pipelines.Pipeline, img image.RGBA) int64 {
 	start := time.Now()
-	engines.ProcessPipeline(&img, &recipe)
+	engines.ProcessPipeline(&img, &pipeline)
 	duration := time.Since(start)
 
 	return duration.Milliseconds()

--- a/internals/api/services/benchmark.go
+++ b/internals/api/services/benchmark.go
@@ -47,7 +47,7 @@ func parseBenchmarkRequest(r *http.Request) (*dto.BenchmarkRequestDTO, int, stri
 		return nil, http.StatusBadRequest, "Parameter \"sample-size\" must be numeric"
 	}
 
-	recipe, err := pipelines.BuildRecipe(strings.Split(filters, ","))
+	recipe, err := pipelines.NewPipeline(strings.Split(filters, ","))
 	if err != nil {
 		return nil, http.StatusNotFound, fmt.Sprintf("Requested filter \"%s\" does not exist", filters)
 	}
@@ -60,9 +60,9 @@ func parseBenchmarkRequest(r *http.Request) (*dto.BenchmarkRequestDTO, int, stri
 
 // benchmarkRecipe determines the total time spent on a recipe execution,
 // returning the result time in milliseconds.
-func benchmarkRecipe(recipe pipelines.Recipe, img image.RGBA) int64 {
+func benchmarkRecipe(recipe pipelines.Pipeline, img image.RGBA) int64 {
 	start := time.Now()
-	engines.ProcessRecipe(&img, &recipe)
+	engines.ProcessPipeline(&img, &recipe)
 	duration := time.Since(start)
 
 	return duration.Milliseconds()

--- a/internals/api/services/benchmark.go
+++ b/internals/api/services/benchmark.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"encoding/json"
 	"fmt"
 	"image"
 	"net/http"
@@ -27,12 +26,7 @@ func BenchmarkHandler(w http.ResponseWriter, r *http.Request) {
 	concurrentRuntime := benchmarkPipeline(requestData.Recipe, *dummyImg)
 
 	response := dto.BuildBenchmarkResponse(requestData.TestImageSize, serialRuntime, concurrentRuntime)
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
+	sendJSONResponse(w, response, statusCode)
 }
 
 // parseBenchmarkRequest extract and validates parameters from the HTTP request

--- a/internals/api/services/benchmark.go
+++ b/internals/api/services/benchmark.go
@@ -22,8 +22,8 @@ func BenchmarkHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dummyImg := image.NewRGBA(image.Rect(0, 0, requestData.TestImageSize, requestData.TestImageSize))
-	serialRuntime := benchmarkPipeline(requestData.Recipe, *dummyImg)
-	concurrentRuntime := benchmarkPipeline(requestData.Recipe, *dummyImg)
+	serialRuntime := benchmarkRecipe(requestData.Recipe, *dummyImg)
+	concurrentRuntime := benchmarkRecipe(requestData.Recipe, *dummyImg)
 
 	response := dto.BuildBenchmarkResponse(requestData.TestImageSize, serialRuntime, concurrentRuntime)
 	sendJSONResponse(w, response, statusCode)
@@ -58,7 +58,9 @@ func parseBenchmarkRequest(r *http.Request) (*dto.BenchmarkRequestDTO, int, stri
 	}, http.StatusOK, ""
 }
 
-func benchmarkPipeline(recipe pipelines.Recipe, img image.RGBA) int64 {
+// benchmarkRecipe determines the total time spent on a recipe execution,
+// returning the result time in milliseconds.
+func benchmarkRecipe(recipe pipelines.Recipe, img image.RGBA) int64 {
 	start := time.Now()
 	engines.ProcessRecipe(&img, &recipe)
 	duration := time.Since(start)

--- a/internals/api/services/helpers.go
+++ b/internals/api/services/helpers.go
@@ -1,8 +1,10 @@
 package services
 
 import (
+	"encoding/json"
 	"image"
 	"image/draw"
+	"net/http"
 )
 
 // convertImageToRGBA takes a image passed through a multipart/form-data request
@@ -16,4 +18,15 @@ func convertImageToRGBA(img image.Image) *image.RGBA {
 	rgba := image.NewRGBA(bounds)
 	draw.Draw(rgba, bounds, img, bounds.Min, draw.Src)
 	return rgba
+}
+
+// sendJSONResponse encodes the provided data as a JSON object to be returned
+// as response for a request.
+func sendJSONResponse(w http.ResponseWriter, responseData any, statusCode int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	
+	if err := json.NewEncoder(w).Encode(responseData); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
 }

--- a/internals/api/services/list_filters.go
+++ b/internals/api/services/list_filters.go
@@ -1,0 +1,16 @@
+package services
+
+import (
+	"net/http"
+
+	"dougdomingos.com/image-filters/filters"
+	"dougdomingos.com/image-filters/internals/api/dto"
+)
+
+// ListFilterHandler provides a service to list all avaliable filters in the
+// API.
+func ListFilterHandler(w http.ResponseWriter, r *http.Request) {
+	filterIDs := filters.GetAvaliableFilterIDs()
+	response := dto.ListFiltersResponse{Filters: filterIDs}
+	sendJSONResponse(w, response, http.StatusOK)
+}

--- a/internals/api/services/processor.go
+++ b/internals/api/services/processor.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,7 +42,7 @@ func ProcessorHandler(w http.ResponseWriter, r *http.Request) {
 // HTTP request intended for the processor service. It enforces constraints on
 // request size (max. 15 MB), required fields, and image format.
 func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, string) {
-	err := r.ParseMultipartForm(15 << 20)
+	err := r.ParseMultipartForm(getRequestMaxSize())
 	if err != nil {
 		var maxBytesErr *http.MaxBytesError
 		if errors.As(err, &maxBytesErr) {
@@ -77,4 +78,18 @@ func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, stri
 		ImgFilename: header.Filename,
 		Recipe:      recipe,
 	}, http.StatusOK, ""
+}
+
+
+// getRequestMaxSize returns the maximum accepted size for processor requests
+// (in bytes). It reads the MAX_REQUEST_SIZE environment variable and defaults
+// to 10 MB if the variable has an invalid value.
+func getRequestMaxSize() int64 {
+	maxSizeInMB, err := strconv.Atoi(os.Getenv("MAX_REQUEST_SIZE"))
+	if err != nil {
+		maxSizeInMB = 10
+	}
+
+	maxSizeInBytes := maxSizeInMB << 20
+	return int64(maxSizeInBytes)
 }

--- a/internals/api/services/processor.go
+++ b/internals/api/services/processor.go
@@ -25,7 +25,7 @@ func ProcessorHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rgbaImage := convertImageToRGBA(requestData.Img)
-	if err := engines.ProcessPipeline(rgbaImage, &requestData.Recipe); err != nil {
+	if err := engines.ProcessPipeline(rgbaImage, &requestData.Pipeline); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -64,7 +64,7 @@ func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, stri
 		return nil, http.StatusBadRequest, "Parameter \"filters\" is required"
 	}
 
-	recipe, err := pipelines.NewPipeline(strings.Split(filters, ","))
+	pipeline, err := pipelines.NewPipeline(strings.Split(filters, ","))
 	if err != nil {
 		return nil, http.StatusNotFound, "Requested filter does not exist"
 	}
@@ -78,7 +78,7 @@ func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, stri
 		Img:         img,
 		ImgFormat:   format,
 		ImgFilename: header.Filename,
-		Recipe:      recipe,
+		Pipeline:    pipeline,
 	}, http.StatusOK, ""
 }
 

--- a/internals/api/services/processor.go
+++ b/internals/api/services/processor.go
@@ -25,7 +25,7 @@ func ProcessorHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rgbaImage := convertImageToRGBA(requestData.Img)
-	engines.ProcessRecipe(rgbaImage, &requestData.Recipe)
+	engines.ProcessPipeline(rgbaImage, &requestData.Recipe)
 
 	outputDir := os.Getenv("API_OUTPUT_DIR")
 	outputFilename := utils.GetProcessedImageFilename(requestData.ImgFilename, time.Now().Format("20060102_150405"))
@@ -50,7 +50,7 @@ func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, stri
 		}
 		return nil, http.StatusBadRequest, "Malformed multipart/form-data request"
 	}
-	
+
 	file, header, err := r.FormFile("image")
 	if err != nil {
 		return nil, http.StatusBadRequest, "No image provided"
@@ -62,7 +62,7 @@ func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, stri
 		return nil, http.StatusBadRequest, "Parameter \"filters\" is required"
 	}
 
-	recipe, err := pipelines.BuildRecipe(strings.Split(filters, ","))
+	recipe, err := pipelines.NewPipeline(strings.Split(filters, ","))
 	if err != nil {
 		return nil, http.StatusNotFound, "Requested filter does not exist"
 	}
@@ -79,7 +79,6 @@ func parseProcessorRequest(r *http.Request) (*dto.ProcessorRequestDTO, int, stri
 		Recipe:      recipe,
 	}, http.StatusOK, ""
 }
-
 
 // getRequestMaxSize returns the maximum accepted size for processor requests
 // (in bytes). It reads the MAX_REQUEST_SIZE environment variable and defaults

--- a/internals/api/services/processor.go
+++ b/internals/api/services/processor.go
@@ -25,7 +25,9 @@ func ProcessorHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rgbaImage := convertImageToRGBA(requestData.Img)
-	engines.ProcessPipeline(rgbaImage, &requestData.Recipe)
+	if err := engines.ProcessPipeline(rgbaImage, &requestData.Recipe); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 
 	outputDir := os.Getenv("API_OUTPUT_DIR")
 	outputFilename := utils.GetProcessedImageFilename(requestData.ImgFilename, time.Now().Format("20060102_150405"))

--- a/internals/api/services/processor.go
+++ b/internals/api/services/processor.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"encoding/json"
 	"errors"
 	"image"
 	"net/http"
@@ -35,12 +34,7 @@ func ProcessorHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := dto.BuildProcessorResponse(outputFilename)
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
+	sendJSONResponse(w, response, statusCode)
 }
 
 // parseProcessorRequest extracts and validates the required parameters from the

--- a/internals/cli/cli_flags.go
+++ b/internals/cli/cli_flags.go
@@ -27,18 +27,20 @@ func ParseInputFlags() ParsedFlags {
 	return ParsedFlags{
 		ImgPath:       *imgPath,
 		OutputDir:     *outputDir,
-		Filters:       parseMultiValueFlag(filters),
+		Filters:       parseFilterIDList(filters),
 		ListPipelines: *listPipelines,
 	}
 }
 
-func parseMultiValueFlag(rawValue *string) []string {
-	if *rawValue == "" {
-		return nil
+// parseFilterIDList parses a comma-separated string of filter IDs and returns
+// them as a slice of strings. Leading and trailing whitespace around each ID
+// is trimmed. Returns an empty slice if the input is empty.
+func parseFilterIDList(filterList *string) []string {
+	if *filterList == "" {
+		return []string{}
 	}
 
-	// Split and clean the input
-	filters := strings.Split(*rawValue, ",")
+	filters := strings.Split(*filterList, ",")
 	for i := range filters {
 		filters[i] = strings.TrimSpace(filters[i])
 	}

--- a/internals/cli/commands.go
+++ b/internals/cli/commands.go
@@ -38,12 +38,12 @@ func ApplyRecipeToImage(imgPath, outputDir string, filters []string) {
 		terminateWithError(err, OutputDirError)
 	}
 
-	recipe, err := pipelines.BuildRecipe(filters)
+	recipe, err := pipelines.NewPipeline(filters)
 	if err != nil {
 		terminateWithError(err, FilterNotFoundError)
 	}
 
-	engines.ProcessRecipe(imageRGBA, &recipe)
+	engines.ProcessPipeline(imageRGBA, &recipe)
 
 	outputFile := utils.GetProcessedImageFilename(imgPath, time.Now().String())
 	outputPath, err := utils.SaveImage(imageRGBA, format, outputDir, outputFile)

--- a/internals/cli/commands.go
+++ b/internals/cli/commands.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"dougdomingos.com/image-filters/engines"
+	"dougdomingos.com/image-filters/filters"
 	"dougdomingos.com/image-filters/internals/utils"
 	"dougdomingos.com/image-filters/pipelines"
 )
 
 // ListAvaliablePipelines displays the list of all avaliable pipelines.
 func ListAvaliablePipelines() {
-	pipelineIDs := make([]string, 0, len(pipelines.AvaliableFilters))
+	pipelineIDs := make([]string, 0, len(filters.AvaliableFilters))
 
-	for filterKey := range pipelines.AvaliableFilters {
+	for filterKey := range filters.AvaliableFilters {
 		pipelineIDs = append(pipelineIDs, filterKey)
 	}
 

--- a/internals/cli/commands.go
+++ b/internals/cli/commands.go
@@ -20,7 +20,7 @@ func ListAvaliablePipelines() {
 	}
 }
 
-func ApplyRecipeToImage(imgPath, outputDir string, filters []string) {
+func ApplyPipelineToImage(imgPath, outputDir string, filters []string) {
 	imageRGBA, format, err := utils.LoadImage(imgPath)
 	if err != nil {
 		terminateWithError(err, ImageLoadingError)

--- a/internals/cli/commands.go
+++ b/internals/cli/commands.go
@@ -37,7 +37,7 @@ func ApplyPipelineToImage(imgPath, outputDir string, filters []string) {
 	}
 
 	if err := engines.ProcessPipeline(imageRGBA, &pipeline); err != nil {
-		terminateWithError(err, FilterNotFoundError)
+		terminateWithError(err, MalformedPipelineError)
 	}
 
 	outputFile := utils.GetProcessedImageFilename(imgPath, time.Now().String())

--- a/internals/cli/commands.go
+++ b/internals/cli/commands.go
@@ -38,12 +38,14 @@ func ApplyRecipeToImage(imgPath, outputDir string, filters []string) {
 		terminateWithError(err, OutputDirError)
 	}
 
-	recipe, err := pipelines.NewPipeline(filters)
+	pipeline, err := pipelines.NewPipeline(filters)
 	if err != nil {
 		terminateWithError(err, FilterNotFoundError)
 	}
 
-	engines.ProcessPipeline(imageRGBA, &recipe)
+	if err := engines.ProcessPipeline(imageRGBA, &pipeline); err != nil {
+		terminateWithError(err, FilterNotFoundError)
+	}
 
 	outputFile := utils.GetProcessedImageFilename(imgPath, time.Now().String())
 	outputPath, err := utils.SaveImage(imageRGBA, format, outputDir, outputFile)

--- a/internals/cli/commands.go
+++ b/internals/cli/commands.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"sort"
 	"time"
 
 	"dougdomingos.com/image-filters/engines"
@@ -13,16 +12,10 @@ import (
 
 // ListAvaliablePipelines displays the list of all avaliable pipelines.
 func ListAvaliablePipelines() {
-	pipelineIDs := make([]string, 0, len(filters.AvaliableFilters))
-
-	for filterKey := range filters.AvaliableFilters {
-		pipelineIDs = append(pipelineIDs, filterKey)
-	}
-
-	sort.Strings(pipelineIDs)
+	filterIDs := filters.GetAvaliableFilterIDs()
 
 	fmt.Println("Avaliable pipelines:")
-	for _, pipeline := range pipelineIDs {
+	for _, pipeline := range filterIDs {
 		fmt.Printf("\t => %s\n", pipeline)
 	}
 }

--- a/internals/cli/exitcodes.go
+++ b/internals/cli/exitcodes.go
@@ -18,9 +18,13 @@ const (
 	// filter specified by the user.
 	FilterNotFoundError = 4
 
+	// MalformedPipelineError declares the exit code for invalid pipelines
+	// states during execution.
+	MalformedPipelineError = 5
+
 	// OutputDirError declares the exit code for failures when checking the
 	// existence of the specified output directory or creating it if needed.
-	OutputDirError = 5
+	OutputDirError = 6
 )
 
 // terminateWithError prints the error and exits the program with the given code.

--- a/internals/utils/env.go
+++ b/internals/utils/env.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"log"
 	"os"
 )
 
@@ -13,4 +14,16 @@ func GetEnvVar(key string) (string, error) {
 	}
 
 	return value, nil
+}
+
+func EnsureRequiredEnvVars(keys []string) error {
+	for _, key := range keys {
+		if value, err := GetEnvVar(key); err != nil {
+			return fmt.Errorf("missing required environment variable: %s", key)
+		} else {
+			log.Printf("%s: %s", key, value)
+		}
+	}
+
+	return nil
 }

--- a/internals/utils/env.go
+++ b/internals/utils/env.go
@@ -6,22 +6,15 @@ import (
 	"os"
 )
 
-func GetEnvVar(key string) (string, error) {
-	value, isDeclared := os.LookupEnv(key)
-
-	if !isDeclared {
-		return "", fmt.Errorf("[ERROR] Required environment variable \"%s\" is not declared", key)
-	}
-
-	return value, nil
-}
-
+// EnsureRequiredEnvVars verifies if the variables specified through the
+// input slice are declared in the environment. If any variable is not
+// declared, returns an error indicating the missing variable.
 func EnsureRequiredEnvVars(keys []string) error {
 	for _, key := range keys {
-		if value, err := GetEnvVar(key); err != nil {
+		if value, isDeclared := os.LookupEnv(key); !isDeclared {
 			return fmt.Errorf("missing required environment variable: %s", key)
 		} else {
-			log.Printf("%s: %s", key, value)
+			log.Printf("[ENV] %s: %s", key, value)
 		}
 	}
 

--- a/pipelines/types.go
+++ b/pipelines/types.go
@@ -7,35 +7,63 @@ import (
 	"dougdomingos.com/image-filters/filters/types"
 )
 
-type Step struct {
-	Action *types.Action
-	Next   *Step
+// PipelineStep represents a single step in an image processing pipeline. Each
+// step contains a filter and an reference to the next step, which may be nil
+// if the current step is the last in the pipeline.
+type PipelineStep struct {
+
+	// Filter is the filter to be applied at this step.
+	Filter *types.Filter
+
+	// Next is a reference to the Step instance in the pipeline (nil if last)
+	Next *PipelineStep
 }
 
-type Recipe struct {
-	Head *Step
+// Pipeline represents a sequence of filters to be applied in order. Filters
+// are executed one-by-one through linked PipelineStep nodes. The pipeline
+// behaves as a non-persistent queue, as it does not keep its steps as it's
+// exhausted.
+type Pipeline struct {
+
+	// head is the first step in the pipeline.
+	head *PipelineStep
 }
 
-func (recipe *Recipe) NextStep() *Step {
-	if recipe.Head == nil {
+// NextStep returns the current step in the pipeline and removes it from the
+// pipeline, moving to the next step.
+//
+// If the pipeline has been fully consumed (i.e., Head is nil), it returns nil.
+func (pipeline *Pipeline) NextStep() *PipelineStep {
+	if pipeline.head == nil {
 		return nil
 	}
 
-	currentHead := recipe.Head
-	recipe.Head = recipe.Head.Next
+	currentHead := pipeline.head
+	pipeline.head = pipeline.head.Next
 	return currentHead
 }
 
-func BuildRecipe(filterIDs []string) (Recipe, error) {
-	var head, tail *Step
+// IsEmpty checks if the current step at the start of the pipeline is nil.
+func (pipeline *Pipeline) IsEmpty() bool {
+	return pipeline.head == nil
+}
+
+// NewPipeline constructs a Pipeline from a list of filter IDs.
+// Each ID is used to look up a corresponding filter via filters.GetFilter.
+// If any ID is invalid or unrecognized, an error is returned.
+//
+// The resulting Pipeline can be used to sequentially apply each filter
+// to an image in order.
+func NewPipeline(filterIDs []string) (Pipeline, error) {
+	var head, tail *PipelineStep
 
 	for _, id := range filterIDs {
-		pipeline, err := filters.GetFilterAction(id)
+		pipeline, err := filters.GetFilter(id)
 		if err != nil {
-			return Recipe{}, fmt.Errorf("[ERROR] No pipeline found for filter \"%q\"", id)
+			return Pipeline{}, fmt.Errorf("[ERROR] No filter found for ID %q", id)
 		}
 
-		node := &Step{Action: &pipeline}
+		node := &PipelineStep{Filter: &pipeline}
 
 		if head == nil {
 			head = node
@@ -46,5 +74,5 @@ func BuildRecipe(filterIDs []string) (Recipe, error) {
 		}
 	}
 
-	return Recipe{Head: head}, nil
+	return Pipeline{head: head}, nil
 }

--- a/pipelines/types.go
+++ b/pipelines/types.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"dougdomingos.com/image-filters/filters"
+	"dougdomingos.com/image-filters/filters/types"
 )
 
 type Step struct {
-	Action *filters.Action
-	Next *Step
+	Action *types.Action
+	Next   *Step
 }
 
 type Recipe struct {
@@ -29,7 +30,7 @@ func BuildRecipe(filterIDs []string) (Recipe, error) {
 	var head, tail *Step
 
 	for _, id := range filterIDs {
-		pipeline, err := GetFilterPipeline(id)
+		pipeline, err := filters.GetFilterAction(id)
 		if err != nil {
 			return Recipe{}, fmt.Errorf("[ERROR] No pipeline found for filter \"%q\"", id)
 		}


### PR DESCRIPTION
This PR simplifies the pipeline architecture and introduces refactoring changes to improve code readability and maintainability.

## Pipeline simplification
- Removes the `Action` layer and transforms the `Filter` type into a struct
  - The function that defines a type is now called `Transformation`
  - As Actions, Filters have a preprocess and a main transformation
  - Filters include methods to create and execute a filter

## Refactoring changes
- `Step` and `Recipe` structs renamed to `PipelineStep` and `Pipeline`, respectively
- Renames variables, attributes and functions to match the new struct naming patterns
- Add missing documentation for variables, functions, etc.